### PR TITLE
Add fastlane metadata

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,13 @@
+An alternative app for controlling NUX Mighty series guitar amplifiers
+
+This app aims to cover all of the functionality the original app offers plus many enhancements:
+
+• All amps and effects are enabled for all channels.
+• Ability to save and recall hundreds of presets locally on your mobile device.
+• Improved Jam Tracks functionality. Select any audio file in your device, add preset change events at any point and play along.
+
+The app is open-source. Full code available at https://github.com/tuntorius/mightier_amp
+
+
+
+"NUX" and the "Mighty" amps series are a trademark of CHERUB TECHNOLOGY COMPANY LIMITED.

--- a/fastlane/metadata/android/en-US/images/icon.png
+++ b/fastlane/metadata/android/en-US/images/icon.png
@@ -1,0 +1,1 @@
+../../../../../assets/icon_big.png

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+An alternative app for controlling NUX Mighty amps series.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Mightier Amp


### PR DESCRIPTION
This enables an icon and description in F-Droid which can be controlled by the upstream developer on github, without changing the metadata in F-Droid on gitlab.

Translations in other languages are also possible

I just copied the description from the play store.
